### PR TITLE
feat(auth): implement role-based access, job and proposal endpoints

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/backend/src/main/java/com/angkorlance/backend/advices/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/angkorlance/backend/advices/GlobalExceptionHandler.java
@@ -4,12 +4,15 @@ import com.angkorlance.backend.dto.ApiResponse;
 import com.angkorlance.backend.exception.DuplicateEmailException;
 import com.angkorlance.backend.exception.InvalidCredentialsException;
 import com.angkorlance.backend.exception.InvalidRoleException;
+import com.angkorlance.backend.exception.AccessDeniedException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -67,6 +70,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(new ApiResponse<>(false, "Login failed", errors));
+    }
+
+    // Handle access denied for role-based restrictions
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleAccessDenied(AccessDeniedException ex) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("error", ex.getMessage()); // generic field for frontend
+
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN) // 403
+                .body(new ApiResponse<>(false, "Access denied", errors));
     }
 
     // Handle any other unexpected exceptions

--- a/backend/src/main/java/com/angkorlance/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/angkorlance/backend/config/SecurityConfig.java
@@ -3,12 +3,16 @@ package com.angkorlance.backend.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import com.angkorlance.backend.security.JwtAuthenticationFilter;
+
 @Configuration
+@EnableMethodSecurity // Enables @PreAuthorize annotations
 public class SecurityConfig {
 
     @Bean
@@ -17,14 +21,19 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+            JwtAuthenticationFilter jwtFilter) throws Exception {
         http
-            .csrf(csrf -> csrf.disable()) // Disable CSRF for REST APIs
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/auth/**").permitAll() // register & login public
-                .anyRequest().authenticated()               // other routes require auth
-            )
-            .httpBasic(Customizer.withDefaults()); // temporary basic auth for testing
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll() // public endpoints
+                        .anyRequest().authenticated() // others need JWT
+                )
+                .addFilterBefore(jwtFilter,
+                        org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
+                .httpBasic(Customizer.withDefaults()); // for testing only
+
         return http.build();
     }
+
 }

--- a/backend/src/main/java/com/angkorlance/backend/controller/JobController.java
+++ b/backend/src/main/java/com/angkorlance/backend/controller/JobController.java
@@ -1,0 +1,34 @@
+package com.angkorlance.backend.controller;
+
+import com.angkorlance.backend.dto.ApiResponse;
+import com.angkorlance.backend.dto.JobRequest;
+import com.angkorlance.backend.dto.JobResponse;
+import com.angkorlance.backend.entity.User;
+import com.angkorlance.backend.service.JobService;
+import com.angkorlance.backend.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/jobs")
+public class JobController {
+
+    private final JobService jobService;
+    private final UserService userService;
+
+    public JobController(JobService jobService, UserService userService) {
+        this.jobService = jobService;
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<JobResponse>> createJob(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody JobRequest request) {
+
+        User user = userService.getUserFromToken(authHeader);
+        JobResponse job = jobService.createJob(request, user);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "Job created successfully", job));
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/controller/ProposalController.java
+++ b/backend/src/main/java/com/angkorlance/backend/controller/ProposalController.java
@@ -1,0 +1,41 @@
+package com.angkorlance.backend.controller;
+
+import com.angkorlance.backend.dto.ApiResponse;
+import com.angkorlance.backend.dto.ProposalRequest;
+import com.angkorlance.backend.dto.ProposalResponse;
+import com.angkorlance.backend.entity.User;
+import com.angkorlance.backend.service.ProposalService;
+import com.angkorlance.backend.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/proposals")
+public class ProposalController {
+
+    private final ProposalService proposalService;
+    private final UserService userService;
+
+    public ProposalController(ProposalService proposalService, UserService userService) {
+        this.proposalService = proposalService;
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ProposalResponse>> submitProposal(
+            @RequestHeader("Authorization") String authHeader,
+            @Valid @RequestBody ProposalRequest request) {
+
+        // Extract user from token
+        User freelancer = userService.getUserFromToken(authHeader);
+
+        // Delegate to service — service handles role check & duplicates
+        ProposalResponse response = proposalService.createProposal(request, freelancer);
+
+        return ResponseEntity.ok(
+                new ApiResponse<>(true, "Proposal submitted successfully", response)
+        );
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/dto/JobRequest.java
+++ b/backend/src/main/java/com/angkorlance/backend/dto/JobRequest.java
@@ -1,0 +1,32 @@
+package com.angkorlance.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class JobRequest {
+
+    @NotBlank(message = "Title is required")
+    private String title;
+
+    @NotBlank(message = "Description is required")
+    private String description;
+
+    @NotBlank(message = "Category is required")
+    private String category;
+
+    @NotNull(message = "Budget is required")
+    private Double budget;
+
+    // Getters and Setters
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+
+    public Double getBudget() { return budget; }
+    public void setBudget(Double budget) { this.budget = budget; }
+}

--- a/backend/src/main/java/com/angkorlance/backend/dto/JobResponse.java
+++ b/backend/src/main/java/com/angkorlance/backend/dto/JobResponse.java
@@ -1,0 +1,44 @@
+package com.angkorlance.backend.dto;
+
+import java.time.LocalDateTime;
+
+public class JobResponse {
+
+    private Long id;
+    private Long clientId;
+    private String clientName;
+    private String title;
+    private String description;
+    private String category;
+    private Double budget;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // Constructor
+    public JobResponse(Long id, Long clientId, String clientName, String title, String description,
+                       String category, Double budget, String status, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.clientId = clientId;
+        this.clientName = clientName;
+        this.title = title;
+        this.description = description;
+        this.category = category;
+        this.budget = budget;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Getters
+    public Long getId() { return id; }
+    public Long getClientId() { return clientId; }
+    public String getClientName() { return clientName; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public String getCategory() { return category; }
+    public Double getBudget() { return budget; }
+    public String getStatus() { return status; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/angkorlance/backend/dto/ProposalRequest.java
+++ b/backend/src/main/java/com/angkorlance/backend/dto/ProposalRequest.java
@@ -1,0 +1,28 @@
+package com.angkorlance.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public class ProposalRequest {
+
+    @NotNull(message = "Job ID is required")
+    private Long jobId;
+
+    @NotBlank(message = "Message is required")
+    private String message;
+
+    @NotNull(message = "Proposed price is required")
+    @Positive(message = "Proposed price must be greater than 0")
+    private Double proposedPrice;
+
+    // Getters and setters
+    public Long getJobId() { return jobId; }
+    public void setJobId(Long jobId) { this.jobId = jobId; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public Double getProposedPrice() { return proposedPrice; }
+    public void setProposedPrice(Double proposedPrice) { this.proposedPrice = proposedPrice; }
+}

--- a/backend/src/main/java/com/angkorlance/backend/dto/ProposalResponse.java
+++ b/backend/src/main/java/com/angkorlance/backend/dto/ProposalResponse.java
@@ -1,0 +1,59 @@
+package com.angkorlance.backend.dto;
+
+import java.time.LocalDateTime;
+
+public class ProposalResponse {
+
+    private Long id;
+    private Long jobId;
+    private Long freelancerId;
+    private String freelancerName;
+    private String message;
+    private Double proposedPrice;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // Constructor
+    public ProposalResponse(Long id, Long jobId, Long freelancerId, String freelancerName,
+                            String message, Double proposedPrice, String status,
+                            LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.jobId = jobId;
+        this.freelancerId = freelancerId;
+        this.freelancerName = freelancerName;
+        this.message = message;
+        this.proposedPrice = proposedPrice;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getJobId() { return jobId; }
+    public void setJobId(Long jobId) { this.jobId = jobId; }
+
+    public Long getFreelancerId() { return freelancerId; }
+    public void setFreelancerId(Long freelancerId) { this.freelancerId = freelancerId; }
+
+    public String getFreelancerName() { return freelancerName; }
+    public void setFreelancerName(String freelancerName) { this.freelancerName = freelancerName; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public Double getProposedPrice() { return proposedPrice; }
+    public void setProposedPrice(Double proposedPrice) { this.proposedPrice = proposedPrice; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/angkorlance/backend/exception/AccessDeniedException.java
+++ b/backend/src/main/java/com/angkorlance/backend/exception/AccessDeniedException.java
@@ -1,0 +1,7 @@
+package com.angkorlance.backend.exception;
+
+public class AccessDeniedException extends RuntimeException {
+    public AccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/exception/DuplicateProposalException.java
+++ b/backend/src/main/java/com/angkorlance/backend/exception/DuplicateProposalException.java
@@ -1,0 +1,7 @@
+package com.angkorlance.backend.exception;
+
+public class DuplicateProposalException extends RuntimeException {
+    public DuplicateProposalException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/angkorlance/backend/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.angkorlance.backend.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException (String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/repository/JobRepository.java
+++ b/backend/src/main/java/com/angkorlance/backend/repository/JobRepository.java
@@ -1,0 +1,10 @@
+package com.angkorlance.backend.repository;
+
+import com.angkorlance.backend.entity.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobRepository extends JpaRepository<Job, Long> {
+    // Additional queries if needed, e.g., findByClientId
+}

--- a/backend/src/main/java/com/angkorlance/backend/repository/ProposalRepository.java
+++ b/backend/src/main/java/com/angkorlance/backend/repository/ProposalRepository.java
@@ -1,0 +1,23 @@
+package com.angkorlance.backend.repository;
+
+import com.angkorlance.backend.entity.Proposal;
+import com.angkorlance.backend.entity.Job;
+import com.angkorlance.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ProposalRepository extends JpaRepository<Proposal, Long> {
+
+    // Optional: find all proposals for a job
+    List<Proposal> findByJob(Job job);
+
+    // Optional: find all proposals by a freelancer
+    List<Proposal> findByFreelancer(User freelancer);
+
+    // Optional: find proposal by job and freelancer (for unique constraint check)
+    Optional<Proposal> findByJobAndFreelancer(Job job, User freelancer);
+}

--- a/backend/src/main/java/com/angkorlance/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/angkorlance/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.angkorlance.backend.security;
+
+import com.angkorlance.backend.entity.User;
+import com.angkorlance.backend.service.UserService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final UserService userService;
+
+    public JwtAuthenticationFilter(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        try {
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                User user = userService.getUserFromToken(authHeader);
+
+                // Attach user to Spring Security context
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(user, null, null);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception ex) {
+            SecurityContextHolder.clearContext(); // invalid token
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/security/JwtUtil.java
+++ b/backend/src/main/java/com/angkorlance/backend/security/JwtUtil.java
@@ -84,4 +84,16 @@ public class JwtUtil {
                 .getBody();
         return claims.getExpiration();
     }
+
+    // Extract user ID from token
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey()) // use your secret key
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject()); // subject is the user ID
+    }
+    
 }

--- a/backend/src/main/java/com/angkorlance/backend/service/JobService.java
+++ b/backend/src/main/java/com/angkorlance/backend/service/JobService.java
@@ -1,0 +1,53 @@
+package com.angkorlance.backend.service;
+
+import com.angkorlance.backend.dto.JobRequest;
+import com.angkorlance.backend.dto.JobResponse;
+import com.angkorlance.backend.entity.Job;
+import com.angkorlance.backend.entity.User;
+import com.angkorlance.backend.exception.AccessDeniedException;
+import com.angkorlance.backend.repository.JobRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class JobService {
+
+    private final JobRepository jobRepository;
+
+    public JobService(JobRepository jobRepository) {
+        this.jobRepository = jobRepository;
+    }
+
+    // Create job 
+    public JobResponse createJob(JobRequest request, User user) {
+        if (!"CLIENT".equals(user.getRole().getName())) {
+            throw new AccessDeniedException("Freelancer cannot create job posts");
+        }
+
+        Job job = new Job();
+        job.setClient(user);
+        job.setTitle(request.getTitle());
+        job.setDescription(request.getDescription());
+        job.setCategory(request.getCategory());
+        job.setBudget(request.getBudget());
+        job.setStatus("OPEN");
+        job.setCreatedAt(LocalDateTime.now());
+        job.setUpdatedAt(LocalDateTime.now());
+
+        Job savedJob = jobRepository.save(job);
+
+        return new JobResponse(
+                savedJob.getId(),
+                savedJob.getClient().getId(),
+                savedJob.getClient().getName(),
+                savedJob.getTitle(),
+                savedJob.getDescription(),
+                savedJob.getCategory(),
+                savedJob.getBudget(),
+                savedJob.getStatus(),
+                savedJob.getCreatedAt(),
+                savedJob.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/service/ProposalService.java
+++ b/backend/src/main/java/com/angkorlance/backend/service/ProposalService.java
@@ -1,0 +1,68 @@
+package com.angkorlance.backend.service;
+
+import com.angkorlance.backend.dto.ProposalRequest;
+import com.angkorlance.backend.dto.ProposalResponse;
+import com.angkorlance.backend.entity.Job;
+import com.angkorlance.backend.entity.Proposal;
+import com.angkorlance.backend.entity.User;
+import com.angkorlance.backend.exception.AccessDeniedException;
+import com.angkorlance.backend.exception.DuplicateProposalException;
+import com.angkorlance.backend.repository.JobRepository;
+import com.angkorlance.backend.repository.ProposalRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class ProposalService {
+
+    private final ProposalRepository proposalRepository;
+    private final JobRepository jobRepository;
+
+    public ProposalService(ProposalRepository proposalRepository, JobRepository jobRepository) {
+        this.proposalRepository = proposalRepository;
+        this.jobRepository = jobRepository;
+    }
+
+    // Create a proposal
+    public ProposalResponse createProposal(ProposalRequest request, User freelancer) {
+
+        // Only freelancers can submit proposals
+        if (!"FREELANCER".equals(freelancer.getRole().getName())) {
+            throw new AccessDeniedException("Clients cannot submit proposals");
+        }
+
+        // Find the job
+        Job job = jobRepository.findById(request.getJobId())
+                .orElseThrow(() -> new IllegalArgumentException("Job not found"));
+
+        // Check if the freelancer already submitted a proposal
+        if (proposalRepository.findByJobAndFreelancer(job, freelancer).isPresent()) {
+            throw new DuplicateProposalException("You have already submitted a proposal for this job");
+        }
+
+        // Create and save proposal
+        Proposal proposal = new Proposal();
+        proposal.setJob(job);
+        proposal.setFreelancer(freelancer);
+        proposal.setMessage(request.getMessage());
+        proposal.setProposedPrice(request.getProposedPrice());
+        proposal.setStatus("PENDING");
+        proposal.setCreatedAt(LocalDateTime.now());
+        proposal.setUpdatedAt(LocalDateTime.now());
+
+        Proposal savedProposal = proposalRepository.save(proposal);
+
+        return new ProposalResponse(
+                savedProposal.getId(),
+                savedProposal.getJob().getId(),
+                savedProposal.getFreelancer().getId(),
+                savedProposal.getFreelancer().getName(),
+                savedProposal.getMessage(),
+                savedProposal.getProposedPrice(),
+                savedProposal.getStatus(),
+                savedProposal.getCreatedAt(),
+                savedProposal.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/angkorlance/backend/service/UserService.java
+++ b/backend/src/main/java/com/angkorlance/backend/service/UserService.java
@@ -1,0 +1,42 @@
+package com.angkorlance.backend.service;
+
+import com.angkorlance.backend.entity.User;
+import com.angkorlance.backend.exception.InvalidCredentialsException;
+import com.angkorlance.backend.exception.ResourceNotFoundException;
+import com.angkorlance.backend.repository.UserRepository;
+import com.angkorlance.backend.security.JwtUtil;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    public UserService(JwtUtil jwtUtil, UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+    }
+
+    // Get user by ID
+    public User getById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with ID " + id));
+    }
+
+    // Extract user from Bearer token
+    public User getUserFromToken(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new InvalidCredentialsException("Missing or invalid Authorization header");
+        }
+
+        String token = authHeader.substring(7); // remove "Bearer "
+        if (!jwtUtil.validateToken(token)) {
+            throw new InvalidCredentialsException("Invalid or expired token");
+        }
+
+        Long userId = Long.parseLong(jwtUtil.getEmailFromToken(token)); // we used id as subject
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new InvalidCredentialsException("User not found"));
+    }
+}


### PR DESCRIPTION
Closes #20 
- Added JobService and ProposalService with role checks:
    - Clients can create jobs
    - Freelancers can submit proposals
    - AccessDeniedException thrown if role is not allowed
- Added ProposalRequest, ProposalResponse, JobRequest, JobResponse DTOs
- Implemented ProposalController and JobController with JWT authentication
- Updated JwtUtil to include getUserIdFromToken() for fetching authenticated user
- Added UserService#getById() to retrieve user from database
- GlobalExceptionHandler updated to handle AccessDeniedException and ResourceNotFoundException
- All responses now use ApiResponse<T> for standardized JSON format
- Validation errors return all failed fields in JSON
- Role-based access tested in Postman