### PR TITLE
Fix JWT subject/email mismatch: subject=userId, email stored as claim

### DIFF
--- a/backend/src/main/java/com/angkorlance/backend/security/JwtUtil.java
+++ b/backend/src/main/java/com/angkorlance/backend/security/JwtUtil.java
@@ -1,15 +1,20 @@
 package com.angkorlance.backend.security;
 
-import com.angkorlance.backend.entity.User;
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
+import com.angkorlance.backend.entity.User;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 
 @Component
 public class JwtUtil {
@@ -32,9 +37,10 @@ public class JwtUtil {
         Date expiryDate = new Date(now.getTime() + jwtExpirationMs);
 
         return Jwts.builder()
-                .setSubject(user.getId().toString()) // Use user ID as subject
-                .claim("name", user.getName())       // Embed name
-                .claim("role", user.getRole().getName()) // Embed role
+                .setSubject(user.getId().toString()) // user ID as subject
+                .claim("name", user.getName()) // embed name
+                .claim("role", user.getRole().getName()) // embed role
+                .claim("email", user.getEmail()) // embed email
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -45,9 +51,9 @@ public class JwtUtil {
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .build()
-                .parseClaimsJws(token);
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
             // Could be expired, malformed, or signature invalid
@@ -55,14 +61,24 @@ public class JwtUtil {
         }
     }
 
-    // Extract email (subject) from token
+    // Extract user ID from token
+    public String getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject(); // subject is the user ID
+    }
+
+    // Extract email from token
     public String getEmailFromToken(String token) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(getSigningKey())
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
-        return claims.getSubject();
+        return claims.get("email", String.class);
     }
 
     // Extract role from token


### PR DESCRIPTION
This is a follow-up to the merged auth PR.
Fixes JWT subject vs email mismatch: now subject stores user ID, email is a separate claim.
Renamed getEmailFromToken() to getUserIdFromToken() and added getEmailFromToken() method.