### PR TITLE
Refactor JWT authentication flow to resolve circular dependency

### DIFF
--- a/backend/src/main/java/com/angkorlance/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/angkorlance/backend/security/JwtAuthenticationFilter.java
@@ -1,13 +1,11 @@
 package com.angkorlance.backend.security;
 
 import java.io.IOException;
-import java.util.List;
 
-import com.angkorlance.backend.entity.User;
-import com.angkorlance.backend.service.AuthService;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -20,18 +18,19 @@ import jakarta.servlet.http.HttpServletResponse;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    private final AuthService authService; // inject AuthService instead of repository
+    private final UserDetailsService userDetailsService;
 
-    public JwtAuthenticationFilter(JwtUtil jwtUtil, AuthService authService) {
+    public JwtAuthenticationFilter(JwtUtil jwtUtil,
+            UserDetailsService userDetailsService) {
         this.jwtUtil = jwtUtil;
-        this.authService = authService;
+        this.userDetailsService = userDetailsService;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain)
-                                    throws ServletException, IOException {
+            HttpServletResponse response,
+            FilterChain filterChain)
+            throws ServletException, IOException {
 
         String authHeader = request.getHeader("Authorization");
 
@@ -50,19 +49,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try {
-            // Extract user ID from token and load full user from DB
             String userId = jwtUtil.getUserIdFromToken(token);
-            User user = authService.getUserById(userId);
 
-            // Create Authentication object with full User and current roles
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(
-                            user, // full User object as principal
-                            null,
-                            List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getName()))
-                    );
+            UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
 
-            // Store in SecurityContext
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails,
+                    null,
+                    userDetails.getAuthorities());
+
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
         } catch (Exception e) {

--- a/backend/src/main/java/com/angkorlance/backend/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/angkorlance/backend/service/CustomUserDetailsService.java
@@ -1,0 +1,43 @@
+package com.angkorlance.backend.service;
+
+import java.util.List;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.angkorlance.backend.entity.User;
+import com.angkorlance.backend.repository.UserRepository;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+
+        long userId;
+
+        try {
+            userId = Long.parseLong(id);
+        } catch (NumberFormatException e) {
+            throw new UsernameNotFoundException("Invalid user ID");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getId().toString(),
+                user.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getName()))
+        );
+    }
+}


### PR DESCRIPTION
This PR resolves a circular dependency in the authentication flow caused by AuthService depending on security configuration components while also being referenced within the security chain.

Problem

The previous implementation created a circular dependency between:

AuthService

Security configuration / authentication components

JWT filter layer

This caused bean initialization issues and tightly coupled business logic with the security layer.

Solution

Decoupled AuthService from security configuration components.

Ensured JWT validation and user loading are handled strictly within the security layer.

Clarified separation of responsibilities:

JwtAuthenticationFilter handles token extraction and validation.

UserDetailsService handles user lookup.

AuthService remains responsible for authentication logic only.

Result

Eliminated circular dependency.

Improved separation of concerns.

Cleaner authentication chain.

More maintainable security configuration.